### PR TITLE
Fix errors seen when running benchmarks

### DIFF
--- a/benchmark/benchmark.php
+++ b/benchmark/benchmark.php
@@ -11,22 +11,22 @@ foreach (glob(__DIR__.'/../jsonexamples/*.json') as $key=>$item) {
 
     $jsonString = file_get_contents($item);
 
-    $stime = microtime_float();
+    $stime = hrtime(true);
     simdjson_decode($jsonString, true);
-    $etime = microtime_float();
-    $simdd_time = bcsub($etime, $stime, 8);
+    $etime = hrtime(true);
+    $simdd_time = $etime - $stime;
 
 
-    $stime = microtime_float();
+    $stime = hrtime(true);
     simdjson_is_valid($jsonString);
-    $etime = microtime_float();
-    $simdi_time = bcsub($etime, $stime, 8);
+    $etime = hrtime(true);
+    $simdi_time = $etime - $stime;
 
 
-    $stime = microtime_float();
+    $stime = hrtime(true);
     json_decode($jsonString, true);
-    $etime = microtime_float();
-    $jsond_time = bcsub($etime, $stime, 8);
+    $etime = hrtime(true);
+    $jsond_time = $etime - $stime;
 
 
     $title.= basename($item)."|{$jsond_time}|{$simdd_time}|$simdi_time\n";
@@ -36,8 +36,9 @@ foreach (glob(__DIR__.'/../jsonexamples/*.json') as $key=>$item) {
 echo $title;
 
 
-function microtime_float()
-{
-    list($usec, $sec) = explode(" ", microtime());
-    return bcadd((float)$usec, (float)$sec, 8);
+if (!function_exists('hrtime')) {
+    function hrtime(bool $as_number = false)
+    {
+        return microtime($as_number);
+    }
 }

--- a/benchmark/composer.json
+++ b/benchmark/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "simdjson",
-    "description": "simdjson",
+    "name": "simdjson/bench",
+    "description": "simdjson benchmarker",
     "type": "project",
     "license": "BSD-3-Clause",
     "minimum-stability": "dev",


### PR DESCRIPTION
Composer 2 requires a `/` in `organization/project`

The `bc` extension for `bcadd` is not always available,
and there are more straightforward ways to get floats.

Also, benchmark/README.md seems out of date with the latest commit and php versions - https://github.com/crazyxman/simdjson_php/pull/22 and other changes should have optimized this (e.g. not call strlen), and I'm seeing closer to 2.4x slower for json_decode assoc compared to simdjsonDecodeAssoc in a php 7.4 build with opcache, though that may not reflect whatever settings you used originally

```
\SimdjsonBench\DecodeBench

    jsonDecodeAssoc.........................R5 I4 [μ Mo]/r: 0.00388 0.00381 (ms) [μSD μRSD]/r: 0.000ms 2.53%
    jsonDecode..............................R1 I4 [μ Mo]/r: 0.00400 0.00400 (ms) [μSD μRSD]/r: 0.000ms 0.00%
    simdjsonDecodeAssoc.....................R1 I4 [μ Mo]/r: 0.00160 0.00160 (ms) [μSD μRSD]/r: 0.000ms 0.00%
    simdjsonDecode..........................R3 I4 [μ Mo]/r: 0.00200 0.00200 (ms) [μSD μRSD]/r: 0.000ms 0.00%

4 subjects, 20 iterations, 20 revs, 0 rejects, 0 failures, 0 warnings
(best [mean mode] worst) = 1.600 [2.870 2.852] 1.600 (μs)
⅀T: 57.400μs μSD/r 0.024μs μRSD/r: 0.631%
suite: 134660b4f6b6dcb7202b52b8c9773b19b5357692, date: 2021-12-11, stime: 14:35:29
+-------------+---------------------+--------+----------+-----------+-----------+-------+
| benchmark   | subject             | groups | mem_peak | mean      | best      | diff  |
+-------------+---------------------+--------+----------+-----------+-----------+-------+
| DecodeBench | simdjsonDecodeAssoc | decode | 597,552b | 0.00160ms | 0.00160ms | 1.00x |
| DecodeBench | simdjsonDecode      | decode | 597,520b | 0.00200ms | 0.00200ms | 1.25x |
| DecodeBench | jsonDecodeAssoc     | decode | 597,520b | 0.00388ms | 0.00380ms | 2.43x |
| DecodeBench | jsonDecode          | decode | 597,520b | 0.00400ms | 0.00400ms | 2.50x |
+-------------+---------------------+--------+----------+-----------+-----------+-------+
```