### PR TITLE
Forbid `\0` as the start of object property names, fix arginfo

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -130,6 +130,6 @@ jobs:
         run: |
           for FILE in $(find tests -name '*.diff'); do
             echo $FILE
-            cat FILE
+            cat $FILE
             echo
           done

--- a/simdjson.cpp
+++ b/simdjson.cpp
@@ -25,33 +25,33 @@
 
 ZEND_DECLARE_MODULE_GLOBALS(simdjson);
 
-ZEND_BEGIN_ARG_INFO(simdjson_is_valid_arginfo, 1)
+ZEND_BEGIN_ARG_INFO_EX(simdjson_is_valid_arginfo, 0, 0, 1)
         ZEND_ARG_INFO(0, json)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(simdjson_decode_arginfo, 1)
+ZEND_BEGIN_ARG_INFO_EX(simdjson_decode_arginfo, 0, 0, 1)
         ZEND_ARG_INFO(0, json)
         ZEND_ARG_INFO(0, assoc)
         ZEND_ARG_INFO(0, depth)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(simdjson_key_value_arginfo, 2)
+ZEND_BEGIN_ARG_INFO_EX(simdjson_key_value_arginfo, 0, 0, 2)
         ZEND_ARG_INFO(0, json)
-        ZEND_ARG_INFO(0, key)
-        ZEND_ARG_INFO(0, assoc)
-        ZEND_ARG_INFO(0, depth)
+        ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+        ZEND_ARG_TYPE_INFO(0, assoc, _IS_BOOL, 0)
+        ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(simdjson_key_exists_arginfo, 2)
+ZEND_BEGIN_ARG_INFO_EX(simdjson_key_exists_arginfo, 0, 0, 2)
         ZEND_ARG_INFO(0, json)
-        ZEND_ARG_INFO(0, key)
-        ZEND_ARG_INFO(0, depth)
+        ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+        ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(simdjson_key_count_arginfo, 2)
+ZEND_BEGIN_ARG_INFO_EX(simdjson_key_count_arginfo, 0, 0, 2)
         ZEND_ARG_INFO(0, json)
-        ZEND_ARG_INFO(0, key)
-        ZEND_ARG_INFO(0, depth)
+        ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+        ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 extern bool cplus_simdjson_is_valid(const char *json, size_t len);

--- a/tests/decode_args.phpt
+++ b/tests/decode_args.phpt
@@ -7,16 +7,15 @@ simdjson_decode args test
 --FILE--
 <?php
 $reflection = new \ReflectionFunction('\simdjson_decode');
-var_dump((string) $reflection);
+echo $reflection;
 
 ?>
 --EXPECTF--
-string(204) "Function [ <internal:simdjson> function simdjson_decode ] {
+Function [ <internal:simdjson> function simdjson_decode ] {
 
   - Parameters [3] {
     Parameter #0 [ <required> $json ]
-    Parameter #1 [ <required> $assoc ]
-    Parameter #2 [ <required> $depth ]
+    Parameter #1 [ <optional> $assoc%S ]
+    Parameter #2 [ <optional> $depth%S ]
   }
 }
-"

--- a/tests/decode_invalid_property.phpt
+++ b/tests/decode_invalid_property.phpt
@@ -1,0 +1,65 @@
+--TEST--
+simdjson_decode throws exception if json object has invalid property
+--FILE--
+<?php
+$json = '{"key":[1],"\u0000*\u0000protected": "test"}';
+$jsonRepeatedInvalid = '{"key":{"\u0000*\u0000protected": "test"}, "\u0000*\u0000protected2": "test"}';
+$jsonWithEmptyKey = '{"":true}';
+
+// Convert null bytes to octal "\000" for readability
+function dump($value) {
+    ob_start();
+    var_dump($value);
+    echo addcslashes(ob_get_clean(), "\\\0");
+}
+// allowed for arrays
+dump(simdjson_decode($json, true));
+
+try {
+    simdjson_decode($json);
+} catch (\RuntimeException $e) {
+    var_dump($e->getMessage());
+}
+
+// allowed for arrays
+dump(simdjson_decode($jsonRepeatedInvalid, true));
+
+try {
+    simdjson_decode($jsonRepeatedInvalid);
+} catch (\RuntimeException $e) {
+    var_dump($e->getMessage());
+}
+// The empty key is allowed.
+var_dump(simdjson_decode($jsonWithEmptyKey));
+var_dump(simdjson_decode($jsonWithEmptyKey, true));
+
+?>
+--EXPECT--
+array(2) {
+  ["key"]=>
+  array(1) {
+    [0]=>
+    int(1)
+  }
+  ["\000*\000protected"]=>
+  string(4) "test"
+}
+string(21) "Invalid property name"
+array(2) {
+  ["key"]=>
+  array(1) {
+    ["\000*\000protected"]=>
+    string(4) "test"
+  }
+  ["\000*\000protected2"]=>
+  string(4) "test"
+}
+string(21) "Invalid property name"
+object(stdClass)#2 (1) {
+  [""]=>
+  bool(true)
+}
+array(1) {
+  [""]=>
+  bool(true)
+}

--- a/tests/key_count_args.phpt
+++ b/tests/key_count_args.phpt
@@ -7,16 +7,15 @@ simdjson_key_count args test
 --FILE--
 <?php
 $reflection = new \ReflectionFunction('\simdjson_key_count');
-var_dump((string) $reflection);
+echo $reflection;
 
 ?>
 --EXPECTF--
-string(205) "Function [ <internal:simdjson> function simdjson_key_count ] {
+Function [ <internal:simdjson> function simdjson_key_count ] {
 
   - Parameters [3] {
     Parameter #0 [ <required> $json ]
-    Parameter #1 [ <required> $key ]
-    Parameter #2 [ <required> $depth ]
+    Parameter #1 [ <required> string $key ]
+    Parameter #2 [ <optional> int%S $depth%S ]
   }
 }
-"

--- a/tests/key_exists_args.phpt
+++ b/tests/key_exists_args.phpt
@@ -7,16 +7,15 @@ simdjson_key_exists args test
 --FILE--
 <?php
 $reflection = new \ReflectionFunction('\simdjson_key_exists');
-var_dump((string) $reflection);
+echo $reflection;
 
 ?>
 --EXPECTF--
-string(206) "Function [ <internal:simdjson> function simdjson_key_exists ] {
+Function [ <internal:simdjson> function simdjson_key_exists ] {
 
   - Parameters [3] {
     Parameter #0 [ <required> $json ]
-    Parameter #1 [ <required> $key ]
-    Parameter #2 [ <required> $depth ]
+    Parameter #1 [ <required> string $key ]
+    Parameter #2 [ <optional> int%S $depth%S ]
   }
 }
-"

--- a/tests/key_value_args.phpt
+++ b/tests/key_value_args.phpt
@@ -7,17 +7,16 @@ simdjson_key_value args test
 --FILE--
 <?php
 $reflection = new \ReflectionFunction('\simdjson_key_value');
-var_dump((string) $reflection);
+echo $reflection;
 
 ?>
 --EXPECTF--
-string(244) "Function [ <internal:simdjson> function simdjson_key_value ] {
+Function [ <internal:simdjson> function simdjson_key_value ] {
 
   - Parameters [4] {
     Parameter #0 [ <required> $json ]
-    Parameter #1 [ <required> $key ]
-    Parameter #2 [ <required> $assoc ]
-    Parameter #3 [ <required> $depth ]
+    Parameter #1 [ <required> string $key ]
+    Parameter #2 [ <optional> bool%S $assoc%S ]
+    Parameter #3 [ <optional> int%S $depth%S ]
   }
 }
-"


### PR DESCRIPTION
Also, fix parameter argument info. This is safe to do for global functions.

Debug builds of recent php minor releases will have an assertion failure
due to expecting the function should throw given the previously
inaccurate arg info.