### PR TITLE
Don't truncate depth to unsigned short, fix crash in simdjson_key_count

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -110,6 +110,7 @@ jobs:
       - name: "Build extension"
         env:
           NO_INTERACTION: true
+          REPORT_EXIT_STATUS: 1
         run: |
           php-config --extension-dir
           phpize

--- a/docker_php7.1-alpine
+++ b/docker_php7.1-alpine
@@ -14,6 +14,8 @@ ENV PHPIZE_DEPS \
     git \
     re2c
 
+ENV REPORT_EXIT_STATUS=1
+
 RUN set -xe \
     && apk add --no-cache --virtual .build-deps \
         $PHPIZE_DEPS \

--- a/docker_php7.2-alpine
+++ b/docker_php7.2-alpine
@@ -14,6 +14,8 @@ ENV PHPIZE_DEPS \
     git \
     re2c
 
+ENV REPORT_EXIT_STATUS=1
+
 RUN set -xe \
     && apk add --no-cache --virtual .build-deps \
         $PHPIZE_DEPS \

--- a/docker_php7.3-alpine
+++ b/docker_php7.3-alpine
@@ -14,6 +14,8 @@ ENV PHPIZE_DEPS \
     git \
     re2c
 
+ENV REPORT_EXIT_STATUS=1
+
 RUN set -xe \
     && apk add --no-cache --virtual .build-deps \
         $PHPIZE_DEPS \

--- a/docker_php7.4-alpine
+++ b/docker_php7.4-alpine
@@ -14,6 +14,8 @@ ENV PHPIZE_DEPS \
     git \
     re2c
 
+ENV REPORT_EXIT_STATUS=1
+
 RUN set -xe \
     && apk add --no-cache --virtual .build-deps \
         $PHPIZE_DEPS \

--- a/docker_php8.0-alpine
+++ b/docker_php8.0-alpine
@@ -14,6 +14,8 @@ ENV PHPIZE_DEPS \
     git \
     re2c
 
+ENV REPORT_EXIT_STATUS=1
+
 RUN set -xe \
     && apk add --no-cache --virtual .build-deps \
         $PHPIZE_DEPS \

--- a/docker_php8.1-alpine
+++ b/docker_php8.1-alpine
@@ -14,6 +14,8 @@ ENV PHPIZE_DEPS \
     git \
     re2c
 
+ENV REPORT_EXIT_STATUS=1
+
 RUN set -xe \
     && apk add --no-cache --virtual .build-deps \
         $PHPIZE_DEPS \

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -35,7 +35,7 @@ get_key_with_optional_prefix(simdjson::dom::element &doc, std::string_view json_
 
 static simdjson::error_code
 build_parsed_json_cust(simdjson::dom::element &doc, const char *buf, size_t len, bool realloc_if_needed,
-                       u_short depth = simdjson::DEFAULT_MAX_DEPTH) {
+                       size_t depth = simdjson::DEFAULT_MAX_DEPTH) {
     auto error = parser.allocate(len, depth);
 
     if (error) {
@@ -171,7 +171,8 @@ static zval create_object(simdjson::dom::element element) /* {{{ */ {
             for (simdjson::dom::key_value_pair field : simdjson::dom::object(element)) {
                 const char *data = field.key.data();
                 size_t size = field.key.size();
-                if (UNEXPECTED(data[0] == '\0') && UNEXPECTED(size > 0)) {
+				/* PHP 7.1 allowed using the empty string as a property of an object */
+                if (UNEXPECTED(data[0] == '\0') && (PHP_VERSION_ID < 70100 || UNEXPECTED(size > 0))) {
                     if (!EG(exception)) {
                         zend_throw_exception(spl_ce_RuntimeException, "Invalid property name", 0);
                     }
@@ -210,7 +211,7 @@ bool cplus_simdjson_is_valid(const char *json, size_t len) /* {{{ */ {
 
 /* }}} */
 
-void cplus_simdjson_parse(const char *json, size_t len, zval *return_value, unsigned char assoc, u_short depth) /* {{{ */ {
+void cplus_simdjson_parse(const char *json, size_t len, zval *return_value, unsigned char assoc, size_t depth) /* {{{ */ {
     simdjson::dom::element doc;
     auto error = build_parsed_json_cust(doc, json, len, true, depth);
     if (error) {
@@ -226,7 +227,7 @@ void cplus_simdjson_parse(const char *json, size_t len, zval *return_value, unsi
 }
 /* }}} */
 void cplus_simdjson_key_value(const char *json, size_t len, const char *key, zval *return_value, unsigned char assoc,
-                              u_short depth) /* {{{ */ {
+                              size_t depth) /* {{{ */ {
     simdjson::dom::element doc;
     simdjson::dom::element element;
     auto error = build_parsed_json_cust(doc, json, len, true, depth);
@@ -251,7 +252,7 @@ void cplus_simdjson_key_value(const char *json, size_t len, const char *key, zva
 
 /* }}} */
 
-u_short cplus_simdjson_key_exists(const char *json, size_t len, const char *key, u_short depth) /* {{{ */ {
+u_short cplus_simdjson_key_exists(const char *json, size_t len, const char *key, size_t depth) /* {{{ */ {
     simdjson::dom::element doc;
     auto error = build_parsed_json_cust(doc, json, len, true, depth);
     if (error) {
@@ -267,7 +268,7 @@ u_short cplus_simdjson_key_exists(const char *json, size_t len, const char *key,
 /* }}} */
 
 
-void cplus_simdjson_key_count(const char *json, size_t len, const char *key, zval *return_value, u_short depth) /* {{{ */ {
+void cplus_simdjson_key_count(const char *json, size_t len, const char *key, zval *return_value, size_t depth) /* {{{ */ {
     simdjson::dom::element doc;
     simdjson::dom::element element;
 

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -16,10 +16,10 @@
 extern "C" {
 #endif
     bool cplus_simdjson_is_valid(const char *json, size_t len);
-    void cplus_simdjson_parse(const char *json, size_t len, zval *return_value, unsigned char assoc, u_short depth);
-    void cplus_simdjson_key_value(const char *json, size_t len, const char *key, zval *return_value, unsigned char assoc, u_short depth);
-    u_short cplus_simdjson_key_exists(const char *json, size_t len, const char *key, u_short depth);
-    void cplus_simdjson_key_count(const char *json, size_t len, const char *key, zval *return_value, u_short depth);
+    void cplus_simdjson_parse(const char *json, size_t len, zval *return_value, unsigned char assoc, size_t depth);
+    void cplus_simdjson_key_value(const char *json, size_t len, const char *key, zval *return_value, unsigned char assoc, size_t depth);
+    u_short cplus_simdjson_key_exists(const char *json, size_t len, const char *key, size_t depth);
+    void cplus_simdjson_key_count(const char *json, size_t len, const char *key, zval *return_value, size_t depth);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/decode_invalid_property.phpt
+++ b/tests/decode_invalid_property.phpt
@@ -1,5 +1,7 @@
 --TEST--
 simdjson_decode throws exception if json object has invalid property
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70100) { echo "skip empty string not allowed as property in php 7.0\n"; } ?>
 --FILE--
 <?php
 $json = '{"key":[1],"\u0000*\u0000protected": "test"}';

--- a/tests/depth.phpt
+++ b/tests/depth.phpt
@@ -1,0 +1,52 @@
+--TEST--
+simdjson_decode depth checked
+--INI--
+display_errors=stderr
+error_reporting=E_ALL
+--FILE--
+<?php
+var_dump(simdjson_decode('[]', true, 0));
+var_dump(simdjson_key_value('[]', '', true, 0));
+var_dump(simdjson_key_count('[]', '', 1));
+var_dump(simdjson_decode('[]', true, 1));
+echo "Test '[1]'\n";
+try {
+    var_dump(simdjson_decode('[1]', true, 1));
+} catch (RuntimeException $e) {
+    echo "Caught for [1]: {$e->getMessage()}\n";
+}
+var_dump(simdjson_decode('[1]', true, 2));
+// XXX there's a difference between simdjson_decode and json_decode.
+// In json_decode, an array with no elements has the same depth as an array of scalars.
+// In simdjson_decode, an array with no elements is deeper than an array with no elements.
+// For typical use cases this shouldn't matter.
+try {
+    var_dump(simdjson_decode('[[1]]', true, 2));
+} catch (RuntimeException $e) {
+    echo "Caught for [[1]]: {$e->getMessage()}\n";
+}
+var_dump(simdjson_decode('[[1]]', true, 3));
+
+?>
+--EXPECTF--
+Warning: simdjson_decode(): Depth must be greater than zero in %s on line 2
+NULL
+Warning: simdjson_key_value(): Depth must be greater than zero in %s on line 3
+NULL
+int(0)
+array(0) {
+}
+Test '[1]'
+Caught for [1]: The JSON document was too deep (too many nested objects and arrays)
+array(1) {
+  [0]=>
+  int(1)
+}
+Caught for [[1]]: The JSON document was too deep (too many nested objects and arrays)
+array(1) {
+  [0]=>
+  array(1) {
+    [0]=>
+    int(1)
+  }
+}

--- a/tests/key_count_exception.phpt
+++ b/tests/key_count_exception.phpt
@@ -9,11 +9,18 @@ simdjson_key_count throws exception if key was not found test
 $json = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'result.json');
 
 try {
-    \simdjson_key_count($json, "unknown", true);
+    \simdjson_key_count($json, "unknown", 1);
+} catch (\RuntimeException $e) {
+    var_dump($e->getMessage());
+}
+
+try {
+    \simdjson_key_count($json, "unknown");
 } catch (\RuntimeException $e) {
     var_dump($e->getMessage());
 }
 
 ?>
---EXPECTF--
+--EXPECT--
+string(67) "The JSON document was too deep (too many nested objects and arrays)"
 string(56) "The JSON field referenced does not exist in this object."


### PR DESCRIPTION
Depth could be a size_t ever since d66fdd950219459fb50b83ea120412eef122080d

- Fix incorrect argument type/position for key_count_exception.phpt
- Properly fail build on older php versions (e.g. 7.0) by setting
  REPORT_EXIT_STATUS
  (newer php versions default it to true instead of false)