### PR TITLE
Make this thread safe, change simdjson_is_valid()

### DIFF
--- a/php_simdjson.h
+++ b/php_simdjson.h
@@ -34,6 +34,12 @@ extern PHPAPI void php_var_dump(zval **struc, int level);
 extern PHPAPI void php_debug_zval_dump(zval **struc, int level);
 
 ZEND_BEGIN_MODULE_GLOBALS(simdjson)
+    /*
+     * php::simdjson::parser pointer, constructed on first use with request-scope lifetime.
+     * Note that in ZTS builds, the thread for each request will deliberately have different instances for each concurrently running request.
+     * (The simdjson library is not thread safe)
+     */
+    void *parser;
 ZEND_END_MODULE_GLOBALS(simdjson)
 
 PHP_MINIT_FUNCTION(simdjson);

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -13,6 +13,8 @@
 
 #include "simdjson.h"
 
+simdjson::dom::parser* cplus_simdjson_create_parser(void);
+void cplus_simdjson_free_parser(simdjson::dom::parser* parser);
 bool cplus_simdjson_is_valid(const char *json, size_t len);
 void cplus_simdjson_parse(const char *json, size_t len, zval *return_value, unsigned char assoc, size_t depth);
 void cplus_simdjson_key_value(const char *json, size_t len, const char *key, zval *return_value, unsigned char assoc, size_t depth);

--- a/tests/is_valid_args.phpt
+++ b/tests/is_valid_args.phpt
@@ -7,14 +7,14 @@ simdjson_is_valid args test
 --FILE--
 <?php
 $reflection = new \ReflectionFunction('\simdjson_is_valid');
-var_dump((string) $reflection);
+echo $reflection;
 
 ?>
 --EXPECTF--
-string(128) "Function [ <internal:simdjson> function simdjson_is_valid ] {
+Function [ <internal:simdjson> function simdjson_is_valid ] {
 
-  - Parameters [1] {
+  - Parameters [2] {
     Parameter #0 [ <required> $json ]
+    Parameter #1 [ <optional> int%S $depth%S ]
   }
 }
-"

--- a/tests/is_valid_edge_cases.phpt
+++ b/tests/is_valid_edge_cases.phpt
@@ -1,0 +1,29 @@
+--TEST--
+simdjson_is_valid edge cases test
+--INI--
+error_reporting=E_ALL
+display_errors=stderr
+--FILE--
+<?php
+var_dump(\simdjson_is_valid('[]', -1));
+var_dump(\simdjson_is_valid('[[]]', 2));
+var_dump(\simdjson_is_valid('[[]]', 1024));
+var_dump(\simdjson_is_valid('[[]]', 1));
+var_dump(\simdjson_is_valid('[[]]'));
+echo "test deeply nested\n";
+$long = str_repeat('[', 3000) . str_repeat(']', 3000);
+var_dump(\simdjson_is_valid($long));
+var_dump(\simdjson_is_valid($long, 2999));
+var_dump(\simdjson_is_valid($long, 3000));
+?>
+--EXPECTF--
+Warning: simdjson_is_valid(): Depth must be greater than zero in %sis_valid_edge_cases.php on line 2
+NULL
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+test deeply nested
+bool(false)
+bool(false)
+bool(true)


### PR DESCRIPTION
- The simdjson parser instances are not thread safe, so the old global
  variable may misbehave on PHP ZTS builds running multiple threads in a
  single process with ZTS PHP builds.
  https://httpd.apache.org/docs/2.4/mpm.html
  Fixes #29
- Free the parser instance when the parser is done processing a request,
  to reclaim memory when php isn't running on web servers
  (e.g. after parsing megabytes of JSON)
- Explicitly set the depth for simdjson_is_valid checks (don't carry
  over last depth implicitly) and allow users to override this.
  Related to #35