### PR TITLE
Cast uint64 to double instead, it exceeds INT64_MAX

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -62,6 +62,7 @@
     <file name="key_value_exception.phpt" role="test"/>
     <file name="key_value_int.phpt" role="test"/>
     <file name="key_value_result.phpt" role="test"/>
+    <file name="uint64_overflow.phpt" role="test"/>
     <file name="_files/result.json" role="test"/>
    </dir>
   </dir>

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -64,7 +64,8 @@ static zval create_array(simdjson::dom::element element) /* {{{ */ {
             break;
         case simdjson::dom::element_type::INT64 : ZVAL_LONG(&v, element.get_int64().value_unsafe());
             break;
-        case simdjson::dom::element_type::UINT64 : ZVAL_LONG(&v, element.get_uint64().value_unsafe());
+            /* UINT64 is used for positive values exceeding INT64_MAX */
+        case simdjson::dom::element_type::UINT64 : ZVAL_DOUBLE(&v, (double)element.get_uint64().value_unsafe());
             break;
         case simdjson::dom::element_type::DOUBLE : ZVAL_DOUBLE(&v, element.get_double().value_unsafe());
             break;
@@ -135,7 +136,8 @@ static zval create_object(simdjson::dom::element element) /* {{{ */ {
             break;
         case simdjson::dom::element_type::INT64 : ZVAL_LONG(&v, element.get_int64().value_unsafe());
             break;
-        case simdjson::dom::element_type::UINT64 : ZVAL_LONG(&v, element.get_uint64().value_unsafe());
+            /* UINT64 is used for positive values exceeding INT64_MAX */
+        case simdjson::dom::element_type::UINT64 : ZVAL_DOUBLE(&v, (double)element.get_uint64().value_unsafe());
             break;
         case simdjson::dom::element_type::DOUBLE : ZVAL_DOUBLE(&v, element.get_double().value_unsafe());
             break;

--- a/tests/uint64_overflow.phpt
+++ b/tests/uint64_overflow.phpt
@@ -1,0 +1,19 @@
+--TEST--
+simdjson_decode uint64_t overflow test
+--FILE--
+<?php
+ini_set('serialize_precision', '20');
+var_export(simdjson_decode('9223372036854775808'));
+echo "\n";
+var_export(simdjson_decode('18446744073709551615'));
+echo "\n";
+try {
+    var_export(simdjson_decode('18446744073709551616'));
+} catch (Exception $e) {
+    printf("%s: %s\n", get_class($e), $e->getMessage());
+}
+?>
+--EXPECT--
+9223372036854775808.0
+18446744073709551616.0
+RuntimeException: Problem while parsing a number


### PR DESCRIPTION
Closes #41

zend_long is a signed int64 on 64-bit php installations - casting uint64s generated by the C library would always overflow zend_long