### PR TITLE
Use EMPTY_SWITCH_DEFAULT_CASE macro

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -116,8 +116,7 @@ static zval create_array(simdjson::dom::element element) /* {{{ */ {
             }
             break;
         }
-        default:
-            break;
+        EMPTY_SWITCH_DEFAULT_CASE();
     }
 
     return v;
@@ -191,8 +190,7 @@ static zval create_object(simdjson::dom::element element) /* {{{ */ {
             }
             break;
         }
-        default:
-            break;
+        EMPTY_SWITCH_DEFAULT_CASE();
     }
     return v;
 }


### PR DESCRIPTION
Assert that other types are unreachable in debug builds, avoid
generating code (that would return uninitialized zval for an impossible
case) in optimized builds.