### PR TITLE
Use average in benchmark.php. Show computed relative time

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -3,15 +3,15 @@
 ## Build project
 
 Build the project from the project root folder:
- 
-``` 
+
+```
 phpize
 ./configure
 make
 make test
 ```
 
-## Install PHP Composer dependecies
+## Install PHP Composer dependencies
 
 [Install Composer](https://getcomposer.org/download/) if not already done and execute it in the benchmark folder:
 
@@ -27,27 +27,27 @@ Execute from project root folder:
 php benchmark/vendor/bin/phpbench run --report=table --group decode
 ```
 
-The output should look like this:
+The output should look like this (Example output is using an optimized php 7.4 NTS build with the simdjson Intel/AMD AVX2 implementation):
 
-``` 
+```
 \SimdjsonBench\DecodeBench
 
-    jsonDecodeAssoc.........................R4 I4 [μ Mo]/r: 0.00972 0.00978 (ms) [μSD μRSD]/r: 0.000ms 2.10%
-    jsonDecode..............................R1 I2 [μ Mo]/r: 0.01060 0.01060 (ms) [μSD μRSD]/r: 0.000ms 1.19%
-    simdjsonDecodeAssoc.....................R5 I4 [μ Mo]/r: 0.00580 0.00580 (ms) [μSD μRSD]/r: 0.000ms 3.08%
-    simdjsonDecode..........................R5 I4 [μ Mo]/r: 0.00680 0.00680 (ms) [μSD μRSD]/r: 0.000ms 1.86%
+    jsonDecodeAssoc.........................R1 I1 [μ Mo]/r: 0.00388 0.00381 (ms) [μSD μRSD]/r: 0.000ms 2.53%
+    jsonDecode..............................R1 I4 [μ Mo]/r: 0.00412 0.00419 (ms) [μSD μRSD]/r: 0.000ms 2.38%
+    simdjsonDecodeAssoc.....................R1 I4 [μ Mo]/r: 0.00160 0.00160 (ms) [μSD μRSD]/r: 0.000ms 0.00%
+    simdjsonDecode..........................R5 I4 [μ Mo]/r: 0.00200 0.00200 (ms) [μSD μRSD]/r: 0.000ms 0.00%
 
 4 subjects, 20 iterations, 20 revs, 0 rejects, 0 failures, 0 warnings
-(best [mean mode] worst) = 5.600 [8.230 8.246] 6.000 (μs)
-⅀T: 164.600μs μSD/r 0.159μs μRSD/r: 2.059%
-suite: 1343d64965925446273f4815a25108531738fcaf, date: 2020-08-04, stime: 16:30:36
+(best [mean mode] worst) = 1.600 [2.900 2.900] 1.600 (μs)
+⅀T: 58.000μs μSD/r 0.049μs μRSD/r: 1.226%
+suite: 1348b91b9c795a97081586821cb7ad40fcf92c64, date: 2022-08-17, stime: 00:01:20
 +-------------+---------------------+--------+----------+-----------+-----------+-------+
 | benchmark   | subject             | groups | mem_peak | mean      | best      | diff  |
 +-------------+---------------------+--------+----------+-----------+-----------+-------+
-| DecodeBench | simdjsonDecodeAssoc | decode | 880,864b | 0.00580ms | 0.00560ms | 1.00x |
-| DecodeBench | simdjsonDecode      | decode | 880,856b | 0.00680ms | 0.00660ms | 1.17x |
-| DecodeBench | jsonDecodeAssoc     | decode | 880,856b | 0.00972ms | 0.00940ms | 1.68x |
-| DecodeBench | jsonDecode          | decode | 880,856b | 0.01060ms | 0.01040ms | 1.83x |
+| DecodeBench | simdjsonDecodeAssoc | decode | 597,696b | 0.00160ms | 0.00160ms | 1.00x |
+| DecodeBench | simdjsonDecode      | decode | 597,664b | 0.00200ms | 0.00200ms | 1.25x |
+| DecodeBench | jsonDecodeAssoc     | decode | 597,664b | 0.00388ms | 0.00380ms | 2.43x |
+| DecodeBench | jsonDecode          | decode | 597,664b | 0.00412ms | 0.00400ms | 2.58x |
 +-------------+---------------------+--------+----------+-----------+-----------+-------+
 ```
 
@@ -57,31 +57,31 @@ php benchmark/vendor/bin/phpbench run --report=table --group key_value
 
 The output should look like this:
 
-``` 
+```
 \SimdjsonBench\KeyValueBench
 
-    jsonDecode..............................R1 I4 [μ Mo]/r: 0.00968 0.00962 (ms) [μSD μRSD]/r: 0.000ms 2.11%
-    simdjsonDeepString......................R1 I2 [μ Mo]/r: 0.00240 0.00240 (ms) [μSD μRSD]/r: 0.000ms 0.00%
-    simdjsonDeepStringAssoc.................R1 I2 [μ Mo]/r: 0.00240 0.00240 (ms) [μSD μRSD]/r: 0.000ms 0.00%
-    simdjsonInt.............................R3 I4 [μ Mo]/r: 0.00200 0.00200 (ms) [μSD μRSD]/r: 0.000ms 0.00%
-    simdjsonIntAssoc........................R2 I1 [μ Mo]/r: 0.00220 0.00220 (ms) [μSD μRSD]/r: 0.000ms 0.00%
-    simdjsonArray...........................R1 I2 [μ Mo]/r: 0.00340 0.00340 (ms) [μSD μRSD]/r: 0.000ms 0.00%
-    simdjsonObject..........................R1 I2 [μ Mo]/r: 0.00400 0.00400 (ms) [μSD μRSD]/r: 0.000ms 0.00%
+    jsonDecode..............................R1 I0 [μ Mo]/r: 0.00400 0.00400 (ms) [μSD μRSD]/r: 0.000ms 0.00%
+    simdjsonDeepString......................R5 I4 [μ Mo]/r: 0.00080 0.00080 (ms) [μSD μRSD]/r: 0.000ms 0.00%
+    simdjsonDeepStringAssoc.................R2 I1 [μ Mo]/r: 0.00080 0.00080 (ms) [μSD μRSD]/r: 0.000ms 0.00%
+    simdjsonInt.............................R2 I2 [μ Mo]/r: 0.00060 0.00060 (ms) [μSD μRSD]/r: 0.000ms 0.00%
+    simdjsonIntAssoc........................R5 I4 [μ Mo]/r: 0.00080 0.00080 (ms) [μSD μRSD]/r: 0.000ms 0.00%
+    simdjsonArray...........................R1 I3 [μ Mo]/r: 0.00100 0.00100 (ms) [μSD μRSD]/r: 0.000ms 0.00%
+    simdjsonObject..........................R5 I4 [μ Mo]/r: 0.00100 0.00100 (ms) [μSD μRSD]/r: 0.000ms 0.00%
 
 7 subjects, 35 iterations, 35 revs, 0 rejects, 0 failures, 0 warnings
-(best [mean mode] worst) = 2.000 [3.726 3.717] 2.000 (μs)
-⅀T: 130.400μs μSD/r 0.029μs μRSD/r: 0.301%
-suite: 1343d642240d34ab476549affaa92a81d4f7ce57, date: 2020-08-04, stime: 16:31:43
+(best [mean mode] worst) = 0.600 [1.286 1.286] 0.600 (μs)
+⅀T: 45.000μs μSD/r 0.000μs μRSD/r: 0.000%
+suite: 1348b91bf021f090195aa64f9e32bb9787e2aba7, date: 2022-08-17, stime: 00:00:39
 +---------------+-------------------------+-----------+----------+-----------+-----------+-------+
 | benchmark     | subject                 | groups    | mem_peak | mean      | best      | diff  |
 +---------------+-------------------------+-----------+----------+-----------+-----------+-------+
-| KeyValueBench | simdjsonInt             | key_value | 884,496b | 0.00200ms | 0.00200ms | 1.00x |
-| KeyValueBench | simdjsonIntAssoc        | key_value | 884,504b | 0.00220ms | 0.00220ms | 1.10x |
-| KeyValueBench | simdjsonDeepString      | key_value | 884,504b | 0.00240ms | 0.00240ms | 1.20x |
-| KeyValueBench | simdjsonDeepStringAssoc | key_value | 884,504b | 0.00240ms | 0.00240ms | 1.20x |
-| KeyValueBench | simdjsonArray           | key_value | 884,496b | 0.00340ms | 0.00340ms | 1.70x |
-| KeyValueBench | simdjsonObject          | key_value | 884,496b | 0.00400ms | 0.00400ms | 2.00x |
-| KeyValueBench | jsonDecode              | key_value | 884,496b | 0.00968ms | 0.00940ms | 4.84x |
+| KeyValueBench | simdjsonInt             | key_value | 597,680b | 0.00060ms | 0.00060ms | 1.00x |
+| KeyValueBench | simdjsonDeepString      | key_value | 597,712b | 0.00080ms | 0.00080ms | 1.33x |
+| KeyValueBench | simdjsonDeepStringAssoc | key_value | 597,712b | 0.00080ms | 0.00080ms | 1.33x |
+| KeyValueBench | simdjsonIntAssoc        | key_value | 597,712b | 0.00080ms | 0.00080ms | 1.33x |
+| KeyValueBench | simdjsonArray           | key_value | 597,680b | 0.00100ms | 0.00100ms | 1.67x |
+| KeyValueBench | simdjsonObject          | key_value | 597,680b | 0.00100ms | 0.00100ms | 1.67x |
+| KeyValueBench | jsonDecode              | key_value | 597,680b | 0.00400ms | 0.00400ms | 6.67x |
 +---------------+-------------------------+-----------+----------+-----------+-----------+-------+
 ```
 
@@ -91,28 +91,49 @@ php benchmark/vendor/bin/phpbench run --report=table --group multiple
 
 The output should look like this:
 
-``` 
+```
 \SimdjsonBench\MultipleAccessBench
 
-    simdjsonMultipleAccessSameDocument......R1 I4 [μ Mo]/r: 0.01500 0.01481 (ms) [μSD μRSD]/r: 0.000ms 2.39%
-    simdjsonMultipleAccessDifferentDocument.R5 I4 [μ Mo]/r: 0.01512 0.01537 (ms) [μSD μRSD]/r: 0.000ms 2.31%
+    simdjsonMultipleAccessSameDocument......R5 I4 [μ Mo]/r: 0.00424 0.00420 (ms) [μSD μRSD]/r: 0.000ms 1.89%
+    simdjsonMultipleAccessDifferentDocument.R2 I4 [μ Mo]/r: 0.00472 0.00479 (ms) [μSD μRSD]/r: 0.000ms 2.08%
 
 2 subjects, 10 iterations, 10 revs, 0 rejects, 0 failures, 0 warnings
-(best [mean mode] worst) = 14.600 [15.060 15.088] 15.400 (μs)
-⅀T: 150.600μs μSD/r 0.353μs μRSD/r: 2.346%
-suite: 1343d643ab682962f20a6f8c0f5615c1b987a7bc, date: 2020-08-04, stime: 16:29:21
+(best [mean mode] worst) = 4.200 [4.480 4.497] 4.400 (μs)
+⅀T: 44.800μs μSD/r 0.089μs μRSD/r: 1.981%
+suite: 1348b906f3a3db7db83e25ab05aeb9a8b3091a84, date: 2022-08-16, stime: 23:59:25
 +---------------------+-----------------------------------------+----------+----------+-----------+-----------+-------+
 | benchmark           | subject                                 | groups   | mem_peak | mean      | best      | diff  |
 +---------------------+-----------------------------------------+----------+----------+-----------+-----------+-------+
-| MultipleAccessBench | simdjsonMultipleAccessSameDocument      | multiple | 903,496b | 0.01500ms | 0.01460ms | 1.00x |
-| MultipleAccessBench | simdjsonMultipleAccessDifferentDocument | multiple | 903,496b | 0.01512ms | 0.01460ms | 1.01x |
+| MultipleAccessBench | simdjsonMultipleAccessSameDocument      | multiple | 597,784b | 0.00424ms | 0.00420ms | 1.00x |
+| MultipleAccessBench | simdjsonMultipleAccessDifferentDocument | multiple | 597,784b | 0.00472ms | 0.00460ms | 1.11x |
 +---------------------+-----------------------------------------+----------+----------+-----------+-----------+-------+
 ```
 
 ## Run benchmark
 
-You may run the benchmarks by running the commands:
+You may also run a simpler standalone benchmark script on the JSON files in `jsonexamples` by running the commands:
 
 ```
-php -d extension=modules/simdjson.so benchmark/test.php
+php -d extension=modules/simdjson.so benchmark/benchmark.php
+```
+
+The output should look like this
+
+```
+filename|json_decode|simdjson_decode|simdjson_is_valid|relative_decode|relative_is_valid
+---|:--:|---:|---:|---:|--:
+apache_builds.json|494947|254120|56543|0.51x|0.11x
+canada.json|37145417|10838062|3320384|0.29x|0.09x
+citm_catalog.json|5874904|2776749|919151|0.47x|0.16x
+github_events.json|259100|97268|27053|0.38x|0.10x
+gsoc-2018.json|12669856|3819161|1622433|0.30x|0.13x
+instruments.json|926302|379006|127161|0.41x|0.14x
+marine_ik.json|25719210|13434756|4342874|0.52x|0.17x
+mesh.json|6093213|2881514|1037859|0.47x|0.17x
+mesh.pretty.json|10560292|2920351|1460824|0.28x|0.14x
+numbers.json|940632|293774|191690|0.31x|0.20x
+random.json|2962083|1420896|361135|0.48x|0.12x
+twitter.json|2398937|961927|323916|0.40x|0.14x
+twitterescaped.json|2730841|1077194|498268|0.39x|0.18x
+update-center.json|2875567|1128182|293914|0.39x|0.10x
 ```

--- a/benchmark/benchmark.php
+++ b/benchmark/benchmark.php
@@ -6,39 +6,40 @@
  * Time: 3:32 AM
  */
 
-$title = "filename|json_decode|simdjson_decode|simdjson_is_valid\n---|:--:|---:|---:\n";
-foreach (glob(__DIR__.'/../jsonexamples/*.json') as $key=>$item) {
-
-    $jsonString = file_get_contents($item);
-
-    $stime = hrtime(true);
-    simdjson_decode($jsonString, true);
-    $etime = hrtime(true);
-    $simdd_time = $etime - $stime;
-
-
-    $stime = hrtime(true);
-    simdjson_is_valid($jsonString);
-    $etime = hrtime(true);
-    $simdi_time = $etime - $stime;
-
-
-    $stime = hrtime(true);
-    json_decode($jsonString, true);
-    $etime = hrtime(true);
-    $jsond_time = $etime - $stime;
-
-
-    $title.= basename($item)."|{$jsond_time}|{$simdd_time}|$simdi_time\n";
-
-}
-
-echo $title;
-
-
 if (!function_exists('hrtime')) {
     function hrtime(bool $as_number = false)
     {
         return microtime($as_number);
     }
 }
+
+// Repeat the operation to make benchmark results less random.
+const ITERATIONS = 4;
+
+// Print the amount of nanoseconds taken on average for the functions, as well as the relative amount of time taken compared to json_decode
+$result = "filename|json_decode|simdjson_decode|simdjson_is_valid|relative_decode|relative_is_valid\n---|:--:|---:|---:|---:|--:\n";
+foreach (glob(__DIR__.'/../jsonexamples/*.json') as $item) {
+
+    $jsonString = file_get_contents($item);
+
+    $stime = hrtime(true);
+    for ($i = 0; $i < ITERATIONS; $i++) { simdjson_decode($jsonString, true); }
+    $etime = hrtime(true);
+    $simdd_time = (int)(($etime - $stime) / ITERATIONS);
+
+    $stime = hrtime(true);
+    for ($i = 0; $i < ITERATIONS; $i++) { simdjson_is_valid($jsonString); }
+    $etime = hrtime(true);
+    $simdi_time = (int)(($etime - $stime) / ITERATIONS);
+
+    $stime = hrtime(true);
+    for ($i = 0; $i < ITERATIONS; $i++) { json_decode($jsonString, true); }
+    $etime = hrtime(true);
+    $jsond_time = (int)(($etime - $stime) / ITERATIONS);
+
+    $relative_decode = sprintf('%.2fx', $simdd_time / $jsond_time);
+    $relative_is_valid = sprintf('%.2fx', $simdi_time / $jsond_time);
+    $result.= basename($item)."|{$jsond_time}|{$simdd_time}|$simdi_time|$relative_decode|$relative_is_valid\n";
+}
+
+echo $result;


### PR DESCRIPTION
Update examples in the README using an optimized php 7.4 installation with
the Intel/AMD AVX2 simdjson backend.