### PR TITLE
Fix merge conflicts, fix bugs, test max depth

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -48,7 +48,9 @@
     <file name="decode_args.phpt" role="test"/>
     <file name="decode_exception.phpt" role="test"/>
     <file name="decode_invalid_property.phpt" role="test"/>
+    <file name="decode_max_depth.phpt" role="test"/>
     <file name="decode_result.phpt" role="test"/>
+    <file name="decode_types.phpt" role="test"/>
     <file name="depth.phpt" role="test"/>
     <file name="is_valid.phpt" role="test"/>
     <file name="is_valid_args.phpt" role="test"/>

--- a/php_simdjson.cpp
+++ b/php_simdjson.cpp
@@ -91,7 +91,7 @@ static bool simdjson_validate_depth(zend_long depth) {
         php_error_docref(NULL, E_WARNING, "Depth must be greater than zero");
         return false;
     } else if (UNEXPECTED(depth > SIMDJSON_MAX_DEPTH)) {
-        php_error_docref(NULL, E_WARNING, "Depth exceeds maximum allowed value of %zu", SIMDJSON_MAX_DEPTH);
+        php_error_docref(NULL, E_WARNING, "Depth exceeds maximum allowed value of " ZEND_LONG_FMT, SIMDJSON_MAX_DEPTH);
         return false;
     }
     return true;

--- a/php_simdjson.cpp
+++ b/php_simdjson.cpp
@@ -83,14 +83,27 @@ static simdjson::dom::parser &simdjson_get_parser() {
     return *parser;
 }
 
+// The simdjson parser accepts strings with at most 32-bit lengths, for now.
+#define SIMDJSON_MAX_DEPTH ((zend_long)((SIZE_MAX / 8) < (UINT32_MAX / 2) ? (SIZE_MAX / 8) : (UINT32_MAX / 2)))
+
+static bool simdjson_validate_depth(zend_long depth) {
+    if (UNEXPECTED(depth <= 0)) {
+        php_error_docref(NULL, E_WARNING, "Depth must be greater than zero");
+        return false;
+    } else if (UNEXPECTED(depth > SIMDJSON_MAX_DEPTH)) {
+        php_error_docref(NULL, E_WARNING, "Depth exceeds maximum allowed value of %zu", SIMDJSON_MAX_DEPTH);
+        return false;
+    }
+    return true;
+}
+
 PHP_FUNCTION (simdjson_is_valid) {
     zend_string *json = NULL;
     zend_long depth = SIMDJSON_PARSE_DEFAULT_DEPTH;
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|l", &json, &depth) == FAILURE) {
         return;
     }
-    if (UNEXPECTED(depth <= 0)) {
-        php_error_docref(NULL, E_WARNING, "Depth must be greater than zero");
+    if (!simdjson_validate_depth(depth)) {
         RETURN_NULL();
     }
     bool is_json = cplus_simdjson_is_valid(simdjson_get_parser(), ZSTR_VAL(json), ZSTR_LEN(json), depth);
@@ -104,8 +117,7 @@ PHP_FUNCTION (simdjson_decode) {
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|bl", &json, &assoc, &depth) == FAILURE) {
         return;
     }
-    if (UNEXPECTED(depth <= 0)) {
-        php_error_docref(NULL, E_WARNING, "Depth must be greater than zero");
+    if (!simdjson_validate_depth(depth)) {
         RETURN_NULL();
     }
     cplus_simdjson_parse(simdjson_get_parser(), ZSTR_VAL(json), ZSTR_LEN(json), return_value, assoc, depth);
@@ -120,8 +132,7 @@ PHP_FUNCTION (simdjson_key_value) {
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "zS|bl", &json, &key, &assoc, &depth) == FAILURE) {
         return;
     }
-    if (depth <= 0) {
-        php_error_docref(NULL, E_WARNING, "Depth must be greater than zero");
+    if (!simdjson_validate_depth(depth)) {
         RETURN_NULL();
     }
     if (IS_STRING == Z_TYPE_P(json)) {
@@ -140,8 +151,7 @@ PHP_FUNCTION (simdjson_key_count) {
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "zS|l", &json, &key, &depth) == FAILURE) {
         return;
     }
-    if (UNEXPECTED(depth <= 0)) {
-        php_error_docref(NULL, E_WARNING, "Depth must be greater than zero");
+    if (!simdjson_validate_depth(depth)) {
         RETURN_NULL();
     }
     if (IS_STRING == Z_TYPE_P(json)) {
@@ -160,8 +170,7 @@ PHP_FUNCTION (simdjson_key_exists) {
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "zS|l", &json, &key, &depth) == FAILURE) {
         return;
     }
-    if (UNEXPECTED(depth <= 0)) {
-        php_error_docref(NULL, E_WARNING, "Depth must be greater than zero");
+    if (!simdjson_validate_depth(depth)) {
         return;
     }
     u_short stats = SIMDJSON_PARSE_FAIL;
@@ -247,7 +256,7 @@ PHP_MINFO_FUNCTION (simdjson) {
 
     php_info_print_table_row(2, "Version", PHP_SIMDJSON_VERSION);
     php_info_print_table_row(2, "Support", SIMDJSON_SUPPORT_URL);
-    php_info_print_table_row(2, "Implementation", simdjson::active_implementation->description().c_str());
+    php_info_print_table_row(2, "Implementation", simdjson::get_active_implementation()->description().c_str());
 
     php_info_print_table_end();
 }

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -141,6 +141,9 @@ static zval create_object(simdjson::dom::element element) /* {{{ */ {
         case simdjson::dom::element_type::BOOL :
             ZVAL_BOOL(&v, element.get_bool().value_unsafe());
             break;
+        case simdjson::dom::element_type::NULL_VALUE :
+            ZVAL_NULL(&v);
+            break;
         case simdjson::dom::element_type::ARRAY : {
             const auto json_array = element.get_array().value_unsafe();
 #if PHP_VERSION_ID >= 70300

--- a/tests/decode_max_depth.phpt
+++ b/tests/decode_max_depth.phpt
@@ -1,0 +1,34 @@
+--TEST--
+simdjson_decode reject max depth
+--FILE--
+<?php
+declare(strict_types=1);
+ini_set('error_reporting', (string)E_ALL);
+ini_set('display_errors', 'stderr');
+
+foreach ([1024, PHP_INT_MAX >> 1] as $depth) {
+    $value = \simdjson_decode('[]', true, $depth);
+    var_dump($value);
+    $value = \simdjson_key_count('{"a":"b"}', 'a', $depth);
+    var_dump($value);
+    $value = \simdjson_key_value('{"a":{}}', 'a', true, $depth);
+    var_dump($value);
+    $value = \simdjson_is_valid('{}', $depth);
+    var_dump($value);
+}
+?>
+--EXPECTF--
+array(0) {
+}
+int(0)
+array(0) {
+}
+bool(true)
+Warning: simdjson_decode(): Depth exceeds maximum allowed value of %d in %s on line 7
+NULL
+Warning: simdjson_key_count(): Depth exceeds maximum allowed value of %d in %s on line 9
+NULL
+Warning: simdjson_key_value(): Depth exceeds maximum allowed value of %d in %s on line 11
+NULL
+Warning: simdjson_is_valid(): Depth exceeds maximum allowed value of %d in %s on line 13
+NULL

--- a/tests/decode_types.phpt
+++ b/tests/decode_types.phpt
@@ -1,0 +1,72 @@
+--TEST--
+simdjson_decode test all types
+--FILE--
+<?php
+// Test all types that work both on 32-bit and 64-bit PECL builds.
+$json = '[{}, {"":"b"}, "", "x", 0, -1, 0.5, null, false, true, []]';
+$value = \simdjson_decode($json, false);
+var_dump($value);
+
+$value = \simdjson_decode($json, true);
+var_dump($value);
+
+?>
+--EXPECT--
+array(11) {
+  [0]=>
+  object(stdClass)#1 (0) {
+  }
+  [1]=>
+  object(stdClass)#2 (1) {
+    [""]=>
+    string(1) "b"
+  }
+  [2]=>
+  string(0) ""
+  [3]=>
+  string(1) "x"
+  [4]=>
+  int(0)
+  [5]=>
+  int(-1)
+  [6]=>
+  float(0.5)
+  [7]=>
+  NULL
+  [8]=>
+  bool(false)
+  [9]=>
+  bool(true)
+  [10]=>
+  array(0) {
+  }
+}
+array(11) {
+  [0]=>
+  array(0) {
+  }
+  [1]=>
+  array(1) {
+    [""]=>
+    string(1) "b"
+  }
+  [2]=>
+  string(0) ""
+  [3]=>
+  string(1) "x"
+  [4]=>
+  int(0)
+  [5]=>
+  int(-1)
+  [6]=>
+  float(0.5)
+  [7]=>
+  NULL
+  [8]=>
+  bool(false)
+  [9]=>
+  bool(true)
+  [10]=>
+  array(0) {
+  }
+}


### PR DESCRIPTION
The handling of JSON `null` was accidentally removed when copying code.
Add a regression test.

Check for invalid depth to avoid allocation errors for overflowing size_t.

Switch to get_active_implementation() needed after updating simdjson to 2.x