### PR TITLE
Switch to version 2.0.0, add reflection types

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,8 +18,8 @@
  </lead>
  <date>2022-08-15</date>
  <version>
-  <release>1.0.0</release>
-  <api>1.0.0</api>
+  <release>2.0.0</release>
+  <api>2.0.0</api>
  </version>
  <stability>
   <release>stable</release>
@@ -27,7 +27,7 @@
  </stability>
  <license uri="https://www.php.net/license/3_0.txt">PHP License</license>
  <notes>
-* Initial release
+* Initial PECL release
  </notes>
  <contents>
   <dir name="/">
@@ -50,6 +50,7 @@
     <file name="decode_invalid_property.phpt" role="test"/>
     <file name="decode_max_depth.phpt" role="test"/>
     <file name="decode_result.phpt" role="test"/>
+    <file name="decode_strict_types.phpt" role="test"/>
     <file name="decode_types.phpt" role="test"/>
     <file name="depth.phpt" role="test"/>
     <file name="is_valid.phpt" role="test"/>
@@ -82,21 +83,5 @@
  <providesextension>simdjson</providesextension>
  <extsrcrelease/>
  <changelog>
-  <release>
-   <date>2022-08-15</date>
-   <time>00:00:00</time>
-   <version>
-    <release>1.0.0</release>
-    <api>1.0.0</api>
-   </version>
-   <stability>
-    <release>stable</release>
-    <api>stable</api>
-   </stability>
-   <license uri="http://www.php.net/license/3_0.txt">PHP License</license>
-   <notes>
-* Initial release
-   </notes>
-  </release>
  </changelog>
 </package>

--- a/php_simdjson.h
+++ b/php_simdjson.h
@@ -17,7 +17,7 @@
 extern zend_module_entry simdjson_module_entry;
 #define phpext_simdjson_ptr &simdjson_module_entry
 
-#define PHP_SIMDJSON_VERSION                  "1.0.0"
+#define PHP_SIMDJSON_VERSION                  "2.0.0"
 #define SIMDJSON_SUPPORT_URL                  "https://github.com/crazyxman/simdjson_php"
 #define SIMDJSON_PARSE_FAIL                   0
 #define SIMDJSON_PARSE_SUCCESS                1

--- a/tests/decode_args.phpt
+++ b/tests/decode_args.phpt
@@ -14,8 +14,8 @@ echo $reflection;
 Function [ <internal:simdjson> function simdjson_decode ] {
 
   - Parameters [3] {
-    Parameter #0 [ <required> $json ]
-    Parameter #1 [ <optional> $assoc%S ]
-    Parameter #2 [ <optional> $depth%S ]
+    Parameter #0 [ <required> string $json ]
+    Parameter #1 [ <optional> bool%S $assoc%S ]
+    Parameter #2 [ <optional> int%S $depth%S ]
   }
 }

--- a/tests/decode_strict_types.phpt
+++ b/tests/decode_strict_types.phpt
@@ -1,0 +1,20 @@
+--TEST--
+simdjson_decode uses strict types
+--FILE--
+<?php
+declare(strict_types = 1);
+
+try {
+    var_dump(simdjson_decode(null));
+} catch (Error $e) {
+    printf("Caught %s: %s\n", get_class($e), $e->getMessage());
+}
+try {
+    var_dump(simdjson_key_exists('{}', null));
+} catch (Error $e) {
+    printf("Caught %s: %s\n", get_class($e), $e->getMessage());
+}
+?>
+--EXPECTF--
+Caught TypeError: %Ssimdjson_decode()%S must be of %Stype string, null given
+Caught TypeError: %Ssimdjson_key_exists()%S must be of %Stype string, null given

--- a/tests/is_valid_args.phpt
+++ b/tests/is_valid_args.phpt
@@ -14,7 +14,8 @@ echo $reflection;
 Function [ <internal:simdjson> function simdjson_is_valid ] {
 
   - Parameters [2] {
-    Parameter #0 [ <required> $json ]
+    Parameter #0 [ <required> string $json ]
     Parameter #1 [ <optional> int%S $depth%S ]
   }
+  - Return [ %Sbool%S ]
 }

--- a/tests/key_count_args.phpt
+++ b/tests/key_count_args.phpt
@@ -14,8 +14,9 @@ echo $reflection;
 Function [ <internal:simdjson> function simdjson_key_count ] {
 
   - Parameters [3] {
-    Parameter #0 [ <required> $json ]
+    Parameter #0 [ <required> string $json ]
     Parameter #1 [ <required> string $key ]
     Parameter #2 [ <optional> int%S $depth%S ]
   }
+  - Return [ %Sint%S ]
 }

--- a/tests/key_exists_args.phpt
+++ b/tests/key_exists_args.phpt
@@ -14,8 +14,9 @@ echo $reflection;
 Function [ <internal:simdjson> function simdjson_key_exists ] {
 
   - Parameters [3] {
-    Parameter #0 [ <required> $json ]
+    Parameter #0 [ <required> string $json ]
     Parameter #1 [ <required> string $key ]
     Parameter #2 [ <optional> int%S $depth%S ]
   }
+  - Return [ %Sbool%S ]
 }

--- a/tests/key_value_args.phpt
+++ b/tests/key_value_args.phpt
@@ -14,7 +14,7 @@ echo $reflection;
 Function [ <internal:simdjson> function simdjson_key_value ] {
 
   - Parameters [4] {
-    Parameter #0 [ <required> $json ]
+    Parameter #0 [ <required> string $json ]
     Parameter #1 [ <required> string $key ]
     Parameter #2 [ <optional> bool%S $assoc%S ]
     Parameter #3 [ <optional> int%S $depth%S ]


### PR DESCRIPTION
In php 8, many remaining functions started adding reflection types
(e.g. json_decode started typing `json` as string in 8.0)

Also add return types, accounting for functions currently emitting
notices and returning null.

Change the version to 2.0.0 to avoid confusion with installations of
older 1.0.0 commits of this repo when a PECL release gets created.

Related to #27 