### PR TITLE
Comment out lead section - blank username fails validation

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,16 +10,18 @@
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
+ <!-- https://pecl.php.net/release-upload.php fails with "User does not exist" for blank username, there is no corresponding PECL account.
  <lead>
   <name>Jinxi Wang</name>
   <user></user>
   <email>1054636713@qq.com</email>
   <active>yes</active>
  </lead>
+ -->
  <date>2022-08-30</date>
  <version>
-  <release>2.0.2</release>
-  <api>2.0.2</api>
+  <release>2.0.3</release>
+  <api>2.0.3</api>
  </version>
  <stability>
   <release>stable</release>
@@ -27,7 +29,7 @@
  </stability>
  <license uri="https://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</license>
  <notes>
-* Fix license metadata in package.xml
+* Fix error validating package.xml when uploading to PECL due to blank username of lead without a PECL account.
  </notes>
  <contents>
   <dir name="/">
@@ -86,6 +88,21 @@
  <providesextension>simdjson</providesextension>
  <extsrcrelease/>
  <changelog>
+  <release>
+   <date>2022-08-30</date>
+   <version>
+    <release>2.0.2</release>
+    <api>2.0.2</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</license>
+   <notes>
+* Fix license metadata in package.xml
+   </notes>
+  </release>
   <release>
    <date>2022-08-29</date>
    <version>

--- a/php_simdjson.h
+++ b/php_simdjson.h
@@ -17,7 +17,7 @@
 extern zend_module_entry simdjson_module_entry;
 #define phpext_simdjson_ptr &simdjson_module_entry
 
-#define PHP_SIMDJSON_VERSION                  "2.0.2"
+#define PHP_SIMDJSON_VERSION                  "2.0.3"
 #define SIMDJSON_SUPPORT_URL                  "https://github.com/crazyxman/simdjson_php"
 #define SIMDJSON_PARSE_FAIL                   0
 #define SIMDJSON_PARSE_SUCCESS                1


### PR DESCRIPTION
https://pecl.php.net/release-upload.php fails to upload a release with
"ERROR: User does not exist" for the blank username. Work around that.

CREDITS/source file headers remain the same