### PR TITLE
Don't export symbols by default on Linux/Unix

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -23,6 +23,11 @@ if test "$PHP_SIMDJSON" != "no"; then
     AC_MSG_RESULT([$php_version, ok])
   fi
 
+  dnl Mark symbols hidden by default if the compiler (for example, gcc >= 4)
+  dnl supports it. This can help reduce the binary size and startup time.
+  AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],
+                        [CXXFLAGS="$CXXFLAGS -fvisibility=hidden"])
+
   AC_DEFINE(HAVE_SIMDJSON, 1, [whether simdjson is enabled])
   PHP_NEW_EXTENSION(simdjson, [
       php_simdjson.cpp                    \

--- a/package.xml
+++ b/package.xml
@@ -20,8 +20,8 @@
  -->
  <date>2022-08-30</date>
  <version>
-  <release>2.0.3</release>
-  <api>2.0.3</api>
+  <release>2.0.4dev</release>
+  <api>2.0.4dev</api>
  </version>
  <stability>
   <release>stable</release>
@@ -29,7 +29,7 @@
  </stability>
  <license uri="https://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</license>
  <notes>
-* Fix error validating package.xml when uploading to PECL due to blank username of lead without a PECL account.
+* Add `-fvisibility=hidden` to compiler options to reduce compiled extension size by avoiding exporting symbols by default.
  </notes>
  <contents>
   <dir name="/">
@@ -88,6 +88,21 @@
  <providesextension>simdjson</providesextension>
  <extsrcrelease/>
  <changelog>
+  <release>
+   <date>2022-08-30</date>
+   <version>
+    <release>2.0.3</release>
+    <api>2.0.3</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</license>
+   <notes>
+* Fix error validating package.xml when uploading to PECL due to blank username of lead without a PECL account.
+   </notes>
+  </release>
   <release>
    <date>2022-08-30</date>
    <version>

--- a/php_simdjson.h
+++ b/php_simdjson.h
@@ -17,7 +17,7 @@
 extern zend_module_entry simdjson_module_entry;
 #define phpext_simdjson_ptr &simdjson_module_entry
 
-#define PHP_SIMDJSON_VERSION                  "2.0.3"
+#define PHP_SIMDJSON_VERSION                  "2.0.4dev"
 #define SIMDJSON_SUPPORT_URL                  "https://github.com/crazyxman/simdjson_php"
 #define SIMDJSON_PARSE_FAIL                   0
 #define SIMDJSON_PARSE_SUCCESS                1


### PR DESCRIPTION
By default in gcc, all compiled symbols are exported. This compilation flag changes that behavior, and only exports symbols that are explicitly exported, such as macros.
(Like Windows already does)

With debugging symbols(`-g`): simdjson.so 5213920->5189440 bytes
Without debugging symbols(without `-g`): simdjson.so 242776->224488

This option has been used in other pecls with repeated header includes, e.g. https://github.com/TysonAndre/pecl-teds/blob/main/config.m4
(It's also used when php itself is built - https://github.com/php/php-src/blob/PHP-7.4.30/configure.ac#L259-L262 )