### PR TITLE
Ignore pathologically large depths longer than strlen

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,10 +18,10 @@
   <active>yes</active>
  </lead>
  -->
- <date>2022-08-30</date>
+ <date>2022-09-30</date>
  <version>
-  <release>2.0.4dev</release>
-  <api>2.0.4dev</api>
+  <release>2.0.4</release>
+  <api>2.0.4</api>
  </version>
  <stability>
   <release>stable</release>

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,8 @@
  <license uri="https://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</license>
  <notes>
 * Add `-fvisibility=hidden` to compiler options to reduce compiled extension size by avoiding exporting symbols by default.
+* If the requested json parsing $depth is excessively large when reallocating larger buffers for the C simdjson parser,
+  then internally use a smaller $depth that would behave identically with lower memory usage. (#66)
  </notes>
  <contents>
   <dir name="/">
@@ -54,6 +56,7 @@
     <file name="decode_exception.phpt" role="test"/>
     <file name="decode_invalid_property.phpt" role="test"/>
     <file name="decode_max_depth.phpt" role="test"/>
+    <file name="decode_max_depth_memory_reduction.phpt" role="test"/>
     <file name="decode_result.phpt" role="test"/>
     <file name="decode_strict_types.phpt" role="test"/>
     <file name="decode_types.phpt" role="test"/>

--- a/php_simdjson.h
+++ b/php_simdjson.h
@@ -17,7 +17,7 @@
 extern zend_module_entry simdjson_module_entry;
 #define phpext_simdjson_ptr &simdjson_module_entry
 
-#define PHP_SIMDJSON_VERSION                  "2.0.4dev"
+#define PHP_SIMDJSON_VERSION                  "2.0.4"
 #define SIMDJSON_SUPPORT_URL                  "https://github.com/crazyxman/simdjson_php"
 #define SIMDJSON_PARSE_FAIL                   0
 #define SIMDJSON_PARSE_SUCCESS                1

--- a/tests/decode_max_depth_memory_reduction.phpt
+++ b/tests/decode_max_depth_memory_reduction.phpt
@@ -1,0 +1,35 @@
+--TEST--
+simdjson_decode uses smaller depth than max_depth when safe to do so
+--FILE--
+<?php
+declare(strict_types=1);
+ini_set('error_reporting', (string)E_ALL);
+ini_set('display_errors', 'stderr');
+
+// This should only be allocating a few megabytes of memory, not gigabytes,
+// due to internally choosing a smaller depth that behaves equivalently for excessively large requested depths.
+foreach ([1024, 1 << 27] as $depth) {
+    echo "Test depth=$depth:\n";
+    $value = simdjson_decode('[]', true, $depth);
+    var_dump($value);
+    $value = simdjson_key_count('{"a":"b"}', 'a', $depth);
+    var_dump($value);
+    try {
+        simdjson_decode(str_repeat('[', 200000) . str_repeat(']', 199999), true, $depth);
+        echo "should be invalid\n";
+    } catch (Exception $e) {
+        printf("Caught %s: %s\n", get_class($e), $e->getMessage());
+    }
+}
+?>
+--EXPECT--
+Test depth=1024:
+array(0) {
+}
+int(0)
+Caught RuntimeException: The JSON document was too deep (too many nested objects and arrays)
+Test depth=134217728:
+array(0) {
+}
+int(0)
+Caught RuntimeException: The JSON document has an improper structure: missing or superfluous commas, braces, missing keys, etc.


### PR DESCRIPTION
Closes #66

For example, for parsing strings shorter than the depth, e.g. `simdjson_decode('{}', true, 1000000000)`, we only need a depth that's at least `strlen('{}') === 2` to get identical results for invalid json.

PHP programmers may assume that a large depth is a safe way to avoid depth errors because it was safe for `json_decode`

To avoid allocating too much virtual memory and wasting page table entries or potentially fatal out of memory errors, reduce depth to a safe value behaving the same way if the requested depth is larger than the allocated depth, larger than the string length, and exceeds 100000.
Do this in a way that reduces reallocations.