### PR TITLE
Improve buffer reuse. Check for out of memory error code

### DIFF
--- a/src/bindings.h
+++ b/src/bindings.h
@@ -11,12 +11,29 @@
   +----------------------------------------------------------------------+
 */
 
+#ifndef PHP_SIMDJSON_BINDINGS
+#define PHP_SIMDJSON_BINDINGS
+
 #include "simdjson.h"
 
-simdjson::dom::parser* cplus_simdjson_create_parser(void);
-void cplus_simdjson_free_parser(simdjson::dom::parser* parser);
-bool cplus_simdjson_is_valid(const char *json, size_t len);
-void cplus_simdjson_parse(const char *json, size_t len, zval *return_value, unsigned char assoc, size_t depth);
-void cplus_simdjson_key_value(const char *json, size_t len, const char *key, zval *return_value, unsigned char assoc, size_t depth);
-u_short cplus_simdjson_key_exists(const char *json, size_t len, const char *key, size_t depth);
-void cplus_simdjson_key_count(const char *json, size_t len, const char *key, zval *return_value, size_t depth);
+#define SIMDJSON_DEPTH_CHECK_THRESHOLD     100000
+#define SIMDJSON_CAPACITY_RECLAIM_THRESHOLD 1000000
+
+#define SIMDJSON_SHOULD_REUSE_PARSER(strlen, depth) (EXPECTED((strlen) <= SIMDJSON_DEPTH_CHECK_THRESHOLD && (depth) <= SIMDJSON_DEPTH_CHECK_THRESHOLD))
+
+ZEND_API simdjson::dom::parser* cplus_simdjson_create_parser(void);
+ZEND_API void cplus_simdjson_free_parser(simdjson::dom::parser* parser);
+ZEND_API bool cplus_simdjson_is_valid(simdjson::dom::parser &parser, const char *json, size_t len, size_t depth);
+ZEND_API void cplus_simdjson_parse(simdjson::dom::parser &parser, const char *json, size_t len, zval *return_value, unsigned char assoc, size_t depth);
+ZEND_API void cplus_simdjson_key_value(simdjson::dom::parser &parser, const char *json, size_t len, const char *key, zval *return_value, unsigned char assoc, size_t depth);
+u_short cplus_simdjson_key_exists(simdjson::dom::parser &parser, const char *json, size_t len, const char *key, size_t depth);
+ZEND_API void cplus_simdjson_key_count(simdjson::dom::parser &parser, const char *json, size_t len, const char *key, zval *return_value, size_t depth);
+
+// Emit out of memory errors to make behavior of json_is_valid consistent with other PHP APIs if it returns. https://github.com/crazyxman/simdjson_php/issues/80
+#define SIMDJSON_OUT_OF_MEMORY_ERROR_NORETURN() zend_error_noreturn(E_ERROR, "simdjson_php: Out of memory")
+#define SIMDJSON_TRY_ALLOCATE(parser, capacity, depth) { \
+        auto error = (parser).allocate((capacity), (depth)); \
+        if (UNEXPECTED(error)) { SIMDJSON_OUT_OF_MEMORY_ERROR_NORETURN(); } \
+    }
+
+#endif /* PHP_SIMDJSON_BINDINGS */


### PR DESCRIPTION
Closes #80 - simdjson_is_valid() and other PHP functions would previously return false when out of memory

- Related to #60 - other php apis (using emalloc instead) will also emit fatal errors when out of memory and end the process.

Closes #79 - reuse buffers for strings less than 1000000 bytes and 100000 depth. (Assumes the depth rarely changes in callers)
(Otherwise, create a brand new parser instance and only use that instance once, after which the megabytes of memory will be reclaimed)